### PR TITLE
Remove hard coded English-only semi-localization from language names

### DIFF
--- a/app/js/resources/af.js
+++ b/app/js/resources/af.js
@@ -1,6 +1,6 @@
 sofia.resources['af'] = {
 	"translation": {
-		"name": "Afrikaans (Afrikaans)",
+		"name": "Afrikaans",
 		"menu": {
 			"search": {
 				"placeholder": "Soek"

--- a/app/js/resources/ar.js
+++ b/app/js/resources/ar.js
@@ -1,6 +1,6 @@
 sofia.resources['ar'] = {
 	"translation": {
-		"name": "العربية (Arabic)",
+		"name": "العربية",
 		"menu": {
 			"search": {
 				"placeholder": "بحث"

--- a/app/js/resources/az.js
+++ b/app/js/resources/az.js
@@ -1,6 +1,6 @@
 sofia.resources['az'] = {
 	"translation": {
-		"name": "Azərbaycanca (Azerbaijani)",
+		"name": "Azərbaycanca",
 		"menu": {
 			"search": {
 				"placeholder": "Axtarış"

--- a/app/js/resources/be.js
+++ b/app/js/resources/be.js
@@ -1,6 +1,6 @@
 sofia.resources['be'] = {
 	"translation": {
-		"name": "Беларуская (Belarusian)",
+		"name": "Беларуская",
 		"menu": {
 			"search": {
 				"placeholder": "Пошук"

--- a/app/js/resources/bg.js
+++ b/app/js/resources/bg.js
@@ -1,6 +1,6 @@
 sofia.resources['bg'] = {
 	"translation": {
-		"name": "български (Bulgarian)",
+		"name": "български",
 		"menu": {
 			"search": {
 				"placeholder": "Търсене"

--- a/app/js/resources/bn.js
+++ b/app/js/resources/bn.js
@@ -1,6 +1,6 @@
 sofia.resources['bn'] = {
 	"translation": {
-		"name": "বাংলা (Bengali)",
+		"name": "বাংলা",
 		"menu": {
 			"search": {
 				"placeholder": "অনুসন্ধান"

--- a/app/js/resources/bs.js
+++ b/app/js/resources/bs.js
@@ -1,6 +1,6 @@
 sofia.resources['bs'] = {
 	"translation": {
-		"name": "bosanski (Bosnian)",
+		"name": "bosanski",
 		"menu": {
 			"search": {
 				"placeholder": "Pretraživanje"

--- a/app/js/resources/ca.js
+++ b/app/js/resources/ca.js
@@ -1,6 +1,6 @@
 sofia.resources['ca'] = {
 	"translation": {
-		"name": "català (Catalan)",
+		"name": "català",
 		"menu": {
 			"search": {
 				"placeholder": "Cerca"

--- a/app/js/resources/ceb.js
+++ b/app/js/resources/ceb.js
@@ -1,6 +1,6 @@
 sofia.resources['ceb'] = {
 	"translation": {
-		"name": "Cebuano (Cebuano)",
+		"name": "Cebuano",
 		"menu": {
 			"search": {
 				"placeholder": "Search"

--- a/app/js/resources/cs.js
+++ b/app/js/resources/cs.js
@@ -1,6 +1,6 @@
 sofia.resources['cs'] = {
 	"translation": {
-		"name": "čeština (Czech)",
+		"name": "čeština",
 		"menu": {
 			"search": {
 				"placeholder": "Hledání"

--- a/app/js/resources/cy.js
+++ b/app/js/resources/cy.js
@@ -1,6 +1,6 @@
 sofia.resources['cy'] = {
 	"translation": {
-		"name": "Cymraeg (Welsh)",
+		"name": "Cymraeg",
 		"menu": {
 			"search": {
 				"placeholder": "Chwilio"

--- a/app/js/resources/da.js
+++ b/app/js/resources/da.js
@@ -1,6 +1,6 @@
 sofia.resources['da'] = {
 	"translation": {
-		"name": "Dansk (Danish)",
+		"name": "Dansk",
 		"menu": {
 			"search": {
 				"placeholder": "Søg"

--- a/app/js/resources/de.js
+++ b/app/js/resources/de.js
@@ -1,6 +1,6 @@
 sofia.resources['de'] = {
 	"translation": {
-		"name": "Deutsch (German)",
+		"name": "Deutsch",
 		"menu": {
 			"search": {
 				"placeholder": "Suche"

--- a/app/js/resources/el.js
+++ b/app/js/resources/el.js
@@ -1,6 +1,6 @@
 sofia.resources['el'] = {
 	"translation": {
-		"name": "Ελληνικά (Greek)",
+		"name": "Ελληνικά",
 		"menu": {
 			"search": {
 				"placeholder": "Έρευνα"

--- a/app/js/resources/en.js
+++ b/app/js/resources/en.js
@@ -1,6 +1,6 @@
 sofia.resources['en'] = {
 	"translation": {
-		"name": "English (English)",
+		"name": "English",
 		"menu": {
 			"search": {
 				"placeholder": "Search"

--- a/app/js/resources/eo.js
+++ b/app/js/resources/eo.js
@@ -1,6 +1,6 @@
 sofia.resources['eo'] = {
 	"translation": {
-		"name": "Esperanto (Esperanto)",
+		"name": "Esperanto",
 		"menu": {
 			"search": {
 				"placeholder": "Serĉu"

--- a/app/js/resources/es.js
+++ b/app/js/resources/es.js
@@ -1,6 +1,6 @@
 sofia.resources['es'] = {
 	"translation": {
-		"name": "español (Spanish)",
+		"name": "español",
 		"menu": {
 			"search": {
 				"placeholder": "Búsqueda"

--- a/app/js/resources/et.js
+++ b/app/js/resources/et.js
@@ -1,6 +1,6 @@
 sofia.resources['et'] = {
 	"translation": {
-		"name": "eesti (Estonian)",
+		"name": "eesti",
 		"menu": {
 			"search": {
 				"placeholder": "Otsing"

--- a/app/js/resources/eu.js
+++ b/app/js/resources/eu.js
@@ -1,6 +1,6 @@
 sofia.resources['eu'] = {
 	"translation": {
-		"name": "euskara (Basque)",
+		"name": "euskara",
 		"menu": {
 			"search": {
 				"placeholder": "Search"

--- a/app/js/resources/fa.js
+++ b/app/js/resources/fa.js
@@ -1,6 +1,6 @@
 sofia.resources['fa'] = {
 	"translation": {
-		"name": "فارسی (Persian)",
+		"name": "فارسی",
 		"menu": {
 			"search": {
 				"placeholder": "جستجو"

--- a/app/js/resources/fi.js
+++ b/app/js/resources/fi.js
@@ -1,6 +1,6 @@
 sofia.resources['fi'] = {
 	"translation": {
-		"name": "suomi (Finnish)",
+		"name": "suomi",
 		"menu": {
 			"search": {
 				"placeholder": "Haku"

--- a/app/js/resources/fr.js
+++ b/app/js/resources/fr.js
@@ -1,6 +1,6 @@
 sofia.resources['fr'] = {
 	"translation": {
-		"name": "Français (French)",
+		"name": "Français",
 		"menu": {
 			"search": {
 				"placeholder": "Recherche"

--- a/app/js/resources/ga.js
+++ b/app/js/resources/ga.js
@@ -1,6 +1,6 @@
 sofia.resources['ga'] = {
 	"translation": {
-		"name": "Gaeilge (Irish)",
+		"name": "Gaeilge",
 		"menu": {
 			"search": {
 				"placeholder": "Cuardaigh"

--- a/app/js/resources/gl.js
+++ b/app/js/resources/gl.js
@@ -1,6 +1,6 @@
 sofia.resources['gl'] = {
 	"translation": {
-		"name": "galego (Galician)",
+		"name": "galego",
 		"menu": {
 			"search": {
 				"placeholder": "Buscar"

--- a/app/js/resources/gu.js
+++ b/app/js/resources/gu.js
@@ -1,6 +1,6 @@
 sofia.resources['gu'] = {
 	"translation": {
-		"name": "ગુજરાતી (Gujarati)",
+		"name": "ગુજરાતી",
 		"menu": {
 			"search": {
 				"placeholder": "શોધ"

--- a/app/js/resources/hi.js
+++ b/app/js/resources/hi.js
@@ -1,6 +1,6 @@
 sofia.resources['hi'] = {
 	"translation": {
-		"name": "हिन्दी (Hindi)",
+		"name": "हिन्दी",
 		"menu": {
 			"search": {
 				"placeholder": "खोज"

--- a/app/js/resources/hmn.js
+++ b/app/js/resources/hmn.js
@@ -1,6 +1,6 @@
 sofia.resources['hmn'] = {
 	"translation": {
-		"name": "Hmong (Hmong)",
+		"name": "Hmong",
 		"menu": {
 			"search": {
 				"placeholder": "Nrhiav"

--- a/app/js/resources/hr.js
+++ b/app/js/resources/hr.js
@@ -1,6 +1,6 @@
 sofia.resources['hr'] = {
 	"translation": {
-		"name": "hrvatski (Croatian)",
+		"name": "hrvatski",
 		"menu": {
 			"search": {
 				"placeholder": "Pretraživanje"

--- a/app/js/resources/ht.js
+++ b/app/js/resources/ht.js
@@ -1,6 +1,6 @@
 sofia.resources['ht'] = {
 	"translation": {
-		"name": "Kreyòl Ayisyen (Haitian Creole)",
+		"name": "Kreyòl Ayisyen",
 		"menu": {
 			"search": {
 				"placeholder": "Search"

--- a/app/js/resources/hu.js
+++ b/app/js/resources/hu.js
@@ -1,6 +1,6 @@
 sofia.resources['hu'] = {
 	"translation": {
-		"name": "magyar (Hungarian)",
+		"name": "magyar",
 		"menu": {
 			"search": {
 				"placeholder": "Keresés"

--- a/app/js/resources/id.js
+++ b/app/js/resources/id.js
@@ -1,6 +1,6 @@
 sofia.resources['id'] = {
 	"translation": {
-		"name": "Bahasa Indonesia (Indonesian)",
+		"name": "Bahasa Indonesia",
 		"menu": {
 			"search": {
 				"placeholder": "Pencarian"

--- a/app/js/resources/is.js
+++ b/app/js/resources/is.js
@@ -1,6 +1,6 @@
 sofia.resources['is'] = {
 	"translation": {
-		"name": "íslenska (Icelandic)",
+		"name": "íslenska",
 		"menu": {
 			"search": {
 				"placeholder": "Leita"

--- a/app/js/resources/it.js
+++ b/app/js/resources/it.js
@@ -1,6 +1,6 @@
 sofia.resources['it'] = {
 	"translation": {
-		"name": "italiano (Italian)",
+		"name": "italiano",
 		"menu": {
 			"search": {
 				"placeholder": "Ricerca"

--- a/app/js/resources/iw.js
+++ b/app/js/resources/iw.js
@@ -1,6 +1,6 @@
 sofia.resources['iw'] = {
 	"translation": {
-		"name": "עברית (Hebrew)",
+		"name": "עברית",
 		"menu": {
 			"search": {
 				"placeholder": "לחפש"

--- a/app/js/resources/ja.js
+++ b/app/js/resources/ja.js
@@ -1,6 +1,6 @@
 sofia.resources['ja'] = {
 	"translation": {
-		"name": "日本語 (Japanese)",
+		"name": "日本語",
 		"menu": {
 			"search": {
 				"placeholder": "検索"

--- a/app/js/resources/jw.js
+++ b/app/js/resources/jw.js
@@ -1,6 +1,6 @@
 sofia.resources['jw'] = {
 	"translation": {
-		"name": "Javanese (Javanese)",
+		"name": "Javanese",
 		"menu": {
 			"search": {
 				"placeholder": "Panelusuran"

--- a/app/js/resources/ka.js
+++ b/app/js/resources/ka.js
@@ -1,6 +1,6 @@
 sofia.resources['ka'] = {
 	"translation": {
-		"name": "ქართული (Georgian)",
+		"name": "ქართული",
 		"menu": {
 			"search": {
 				"placeholder": "ძიება"

--- a/app/js/resources/km.js
+++ b/app/js/resources/km.js
@@ -1,6 +1,6 @@
 sofia.resources['km'] = {
 	"translation": {
-		"name": "ភាសាខ្មែរ (Khmer)",
+		"name": "ភាសាខ្មែរ",
 		"menu": {
 			"search": {
 				"placeholder": "ស្វែងរក"

--- a/app/js/resources/kn.js
+++ b/app/js/resources/kn.js
@@ -1,6 +1,6 @@
 sofia.resources['kn'] = {
 	"translation": {
-		"name": "ಕನ್ನಡ (Kannada)",
+		"name": "ಕನ್ನಡ",
 		"menu": {
 			"search": {
 				"placeholder": "ಹುಡುಕು"

--- a/app/js/resources/ko.js
+++ b/app/js/resources/ko.js
@@ -1,6 +1,6 @@
 sofia.resources['ko'] = {
 	"translation": {
-		"name": "한국어 (Korean)",
+		"name": "한국어",
 		"menu": {
 			"search": {
 				"placeholder": "수색"

--- a/app/js/resources/la.js
+++ b/app/js/resources/la.js
@@ -1,6 +1,6 @@
 sofia.resources['la'] = {
 	"translation": {
-		"name": "Latin (Latin)",
+		"name": "Latin",
 		"menu": {
 			"search": {
 				"placeholder": "Lorem ipsum"

--- a/app/js/resources/lo.js
+++ b/app/js/resources/lo.js
@@ -1,6 +1,6 @@
 sofia.resources['lo'] = {
 	"translation": {
-		"name": "ພາສາລາວ (Lao)",
+		"name": "ພາສາລາວ",
 		"menu": {
 			"search": {
 				"placeholder": "ຊອກ​ຫາ"

--- a/app/js/resources/lt.js
+++ b/app/js/resources/lt.js
@@ -1,6 +1,6 @@
 sofia.resources['lt'] = {
 	"translation": {
-		"name": "lietuvių (Lithuanian)",
+		"name": "lietuvių",
 		"menu": {
 			"search": {
 				"placeholder": "Paieška"

--- a/app/js/resources/lv.js
+++ b/app/js/resources/lv.js
@@ -1,6 +1,6 @@
 sofia.resources['lv'] = {
 	"translation": {
-		"name": "latviešu (Latvian)",
+		"name": "latviešu",
 		"menu": {
 			"search": {
 				"placeholder": "Meklēšana"

--- a/app/js/resources/mk.js
+++ b/app/js/resources/mk.js
@@ -1,6 +1,6 @@
 sofia.resources['mk'] = {
 	"translation": {
-		"name": "македонски (Macedonian)",
+		"name": "македонски",
 		"menu": {
 			"search": {
 				"placeholder": "Барај"

--- a/app/js/resources/mr.js
+++ b/app/js/resources/mr.js
@@ -1,6 +1,6 @@
 sofia.resources['mr'] = {
 	"translation": {
-		"name": "मराठी (Marathi)",
+		"name": "मराठी",
 		"menu": {
 			"search": {
 				"placeholder": "शोध"

--- a/app/js/resources/ms.js
+++ b/app/js/resources/ms.js
@@ -1,6 +1,6 @@
 sofia.resources['ms'] = {
 	"translation": {
-		"name": "Bahasa Melayu (Malay)",
+		"name": "Bahasa Melayu",
 		"menu": {
 			"search": {
 				"placeholder": "Carian"

--- a/app/js/resources/mt.js
+++ b/app/js/resources/mt.js
@@ -1,6 +1,6 @@
 sofia.resources['mt'] = {
 	"translation": {
-		"name": "Malti (Maltese)",
+		"name": "Malti",
 		"menu": {
 			"search": {
 				"placeholder": "Fittex"

--- a/app/js/resources/nl.js
+++ b/app/js/resources/nl.js
@@ -1,6 +1,6 @@
 sofia.resources['nl'] = {
 	"translation": {
-		"name": "Nederlands (Dutch)",
+		"name": "Nederlands",
 		"menu": {
 			"search": {
 				"placeholder": "Zoeken"

--- a/app/js/resources/no.js
+++ b/app/js/resources/no.js
@@ -1,6 +1,6 @@
 sofia.resources['no'] = {
 	"translation": {
-		"name": "norsk (Norwegian)",
+		"name": "norsk",
 		"menu": {
 			"search": {
 				"placeholder": "Søk"

--- a/app/js/resources/pl.js
+++ b/app/js/resources/pl.js
@@ -1,6 +1,6 @@
 sofia.resources['pl'] = {
 	"translation": {
-		"name": "polski (Polish)",
+		"name": "polski",
 		"menu": {
 			"search": {
 				"placeholder": "Poszukiwanie"

--- a/app/js/resources/pt.js
+++ b/app/js/resources/pt.js
@@ -1,6 +1,6 @@
 sofia.resources['pt'] = {
 	"translation": {
-		"name": "português (Portuguese)",
+		"name": "português",
 		"menu": {
 			"search": {
 				"placeholder": "Pesquisa"

--- a/app/js/resources/ro.js
+++ b/app/js/resources/ro.js
@@ -1,6 +1,6 @@
 sofia.resources['ro'] = {
 	"translation": {
-		"name": "Română (Romanian)",
+		"name": "Română",
 		"menu": {
 			"search": {
 				"placeholder": "Căutare"

--- a/app/js/resources/ru.js
+++ b/app/js/resources/ru.js
@@ -1,6 +1,6 @@
 sofia.resources['ru'] = {
 	"translation": {
-		"name": "русский (Russian)",
+		"name": "русский",
 		"menu": {
 			"search": {
 				"placeholder": "Поиск"

--- a/app/js/resources/sk.js
+++ b/app/js/resources/sk.js
@@ -1,6 +1,6 @@
 sofia.resources['sk'] = {
 	"translation": {
-		"name": "slovenčina (Slovak)",
+		"name": "slovenčina",
 		"menu": {
 			"search": {
 				"placeholder": "Hľadanie"

--- a/app/js/resources/sl.js
+++ b/app/js/resources/sl.js
@@ -1,6 +1,6 @@
 sofia.resources['sl'] = {
 	"translation": {
-		"name": "slovenščina (Slovenian)",
+		"name": "slovenščina",
 		"menu": {
 			"search": {
 				"placeholder": "Iskanje"

--- a/app/js/resources/sq.js
+++ b/app/js/resources/sq.js
@@ -1,6 +1,6 @@
 sofia.resources['sq'] = {
 	"translation": {
-		"name": "Shqip (Albanian)",
+		"name": "Shqip",
 		"menu": {
 			"search": {
 				"placeholder": "Kërkim"

--- a/app/js/resources/sr.js
+++ b/app/js/resources/sr.js
@@ -1,6 +1,6 @@
 sofia.resources['sr'] = {
 	"translation": {
-		"name": "српски (Serbian)",
+		"name": "српски",
 		"menu": {
 			"search": {
 				"placeholder": "Претраживање"

--- a/app/js/resources/sv.js
+++ b/app/js/resources/sv.js
@@ -1,6 +1,6 @@
 sofia.resources['sv'] = {
 	"translation": {
-		"name": "svenska (Swedish)",
+		"name": "svenska",
 		"menu": {
 			"search": {
 				"placeholder": "Sökning"

--- a/app/js/resources/sw.js
+++ b/app/js/resources/sw.js
@@ -1,6 +1,6 @@
 sofia.resources['sw'] = {
 	"translation": {
-		"name": "Kiswahili (Swahili)",
+		"name": "Kiswahili",
 		"menu": {
 			"search": {
 				"placeholder": "Search"

--- a/app/js/resources/ta.js
+++ b/app/js/resources/ta.js
@@ -1,6 +1,6 @@
 sofia.resources['ta'] = {
 	"translation": {
-		"name": "தமிழ் (Tamil)",
+		"name": "தமிழ்",
 		"menu": {
 			"search": {
 				"placeholder": "தேடுதல்"

--- a/app/js/resources/te.js
+++ b/app/js/resources/te.js
@@ -1,6 +1,6 @@
 sofia.resources['te'] = {
 	"translation": {
-		"name": "తెలుగు (Telugu)",
+		"name": "తెలుగు",
 		"menu": {
 			"search": {
 				"placeholder": "శోధన"

--- a/app/js/resources/th.js
+++ b/app/js/resources/th.js
@@ -1,6 +1,6 @@
 sofia.resources['th'] = {
 	"translation": {
-		"name": "ภาษาไทย (Thai)",
+		"name": "ภาษาไทย",
 		"menu": {
 			"search": {
 				"placeholder": "ค้นหา"

--- a/app/js/resources/tl.js
+++ b/app/js/resources/tl.js
@@ -1,6 +1,6 @@
 sofia.resources['tl'] = {
 	"translation": {
-		"name": "Filipino (Filipino)",
+		"name": "Filipino",
 		"menu": {
 			"search": {
 				"placeholder": "Paghahanap"

--- a/app/js/resources/tr.js
+++ b/app/js/resources/tr.js
@@ -1,6 +1,6 @@
 sofia.resources['tr'] = {
 	"translation": {
-		"name": "Türkçe (Turkish)",
+		"name": "Türkçe",
 		"menu": {
 			"search": {
 				"placeholder": "Arama"

--- a/app/js/resources/uk.js
+++ b/app/js/resources/uk.js
@@ -1,6 +1,6 @@
 sofia.resources['uk'] = {
 	"translation": {
-		"name": "українська (Ukrainian)",
+		"name": "українська",
 		"menu": {
 			"search": {
 				"placeholder": "Пошук"

--- a/app/js/resources/ur.js
+++ b/app/js/resources/ur.js
@@ -1,6 +1,6 @@
 sofia.resources['ur'] = {
 	"translation": {
-		"name": "اردو (Urdu)",
+		"name": "اردو",
 		"menu": {
 			"search": {
 				"placeholder": "تلاش"

--- a/app/js/resources/vi.js
+++ b/app/js/resources/vi.js
@@ -1,6 +1,6 @@
 sofia.resources['vi'] = {
 	"translation": {
-		"name": "Tiếng Việt (Vietnamese)",
+		"name": "Tiếng Việt",
 		"menu": {
 			"search": {
 				"placeholder": "Tìm kiếm"

--- a/app/js/resources/yi.js
+++ b/app/js/resources/yi.js
@@ -1,6 +1,6 @@
 sofia.resources['yi'] = {
 	"translation": {
-		"name": "אידיש (Yiddish)",
+		"name": "אידיש",
 		"menu": {
 			"search": {
 				"placeholder": "זוכן"

--- a/app/js/resources/zh-CN.js
+++ b/app/js/resources/zh-CN.js
@@ -2,7 +2,7 @@
 
 sofia.resources["zh-CN"] = {
 	translation: {
-		name: '中文 (Chinese - Simplified)',
+		name: '中文',
 
 		menu: {
 			search: {

--- a/app/js/resources/zh-TW.js
+++ b/app/js/resources/zh-TW.js
@@ -1,6 +1,6 @@
 sofia.resources['zh-TW'] = {
 	"translation": {
-		"name": "中文(繁體) (Chinese (Traditional))",
+		"name": "中文(繁體)",
 		"menu": {
 			"search": {
 				"placeholder": "搜索"

--- a/app/js/resources/zh.js
+++ b/app/js/resources/zh.js
@@ -1,6 +1,6 @@
 sofia.resources['zh'] = {
 	"translation": {
-		"name": "中文(简体) (Chinese (Simplified))",
+		"name": "中文(简体)",
 		"menu": {
 			"search": {
 				"placeholder": "搜索"


### PR DESCRIPTION
In the process of trying to get a completely localized interface (see also #33 and #32), one thing that was sticking out was the hard coded English strings attached to language names. As explained in the commit message for 4a53bc6, I believe these to be unnecessary and cumbersome.

I would suggest ditching them entirely in favor of just using localized language names. People are going to know where to find and how to read the languages that are of interest to them. Non English speakers are actually going to recognize more of the localized names than they will the EN names.

The only exception that comes to mind is not important for the language selector menu so much as for the names of translations. Namely for Greek and Hebrew I know there are some users with an interest in texts in those languages that don't actually know beans about them. Whether these are the sort of users you want to cater to or not is something I would question¹, but let's assume for now you do. These are a strange beast anyway as the content modules are often catered to an English audience even though the content may be in Greek or Hebrew. The GWH module for example has English delimiters inline in the Greek text.

In any event the current module names are in English anyway, so for now the English usage isn't broken and localizing translation names is something I'll be playing with in my [localization-languages](https://github.com/alerque/browserbible-3/tree/localization-translations) branch and save for a later PR when it gets sorted out.

¹ <sub>If they can't find «עִבְרִית» in a menu how useful is it going to be for them to start readingבְּרֵאשִׁ֖ית בָּרָ֣א» אֱלֹהִ֑ים אֵ֥ת הַשָּׁמַ֖יִם וְאֵ֥ת הָאָֽרֶץ׃»?</sub>
