### PR TITLE
Attach font changer only to font radio buttons

### DIFF
--- a/app/js/menu/config-fontfamily.js
+++ b/app/js/menu/config-fontfamily.js
@@ -76,7 +76,7 @@ var FontFamilySettings = function(node) {
 	}
 
 	// handle clicks
-	body.on('change', 'input', function() {
+	body.on('change', 'input[name=config-font-family]', function() {
 		var radio = $(this),
 			newFontFamilyValue = radio.val();
 


### PR DESCRIPTION
The function to set the font family was being attached to all input
elements in the entire document which included the font-size selector.
The result was that changing the font size would strip the font family
class off the body element and replace it with nonsense like
`class="config-font-family-18"`. This meant every time you adjusted the
size, your font pref disappeared and hand to be reset.

Fixes #20
