### PR TITLE
Fix a typo in generate.js' module docstring.

### DIFF
--- a/tools/textgenerator/generate.js
+++ b/tools/textgenerator/generate.js
@@ -1,6 +1,6 @@
 /**
 * Generates HTML that can function as standalone chapters or as chapters loaded by the main app
-* This attemps to load folders in the ./input/ directory, read the ./input/versoin/info.json and
+* This attemps to load folders in the ./input/ directory, read the ./input/version/info.json and
 * then use a renderer found in ./node_modules/generate_renderername.js
 *
 * See options for details on running


### PR DESCRIPTION
I changed `versoin` to `version`.