### PR TITLE
Natural and uglify-js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ An update to https://github.com/digitalbiblesociety/browserbible.
 
 ### Building Texts ###
 
-1. Install Node.js (http://nodejs.org/download/) for your platform
-2. Navigate to the `/tools/textgenerator` folder
-3. Run `npm install` to install dependencies
-4. Run `node generate.js -a` (`-a` will build every version `input` folder, run without `-a` to see help)
-5. Run `node create_texts_index.js` (this creates a list of all versions to startup the app)
+1. Install Node.js (http://nodejs.org/download/) for your platform.
+2. Install uglify-js and natural `npm install uglify-js natural`
+3. Navigate to the `/tools/textgenerator` folder
+4. Run `npm install` to install dependencies
+5. Run `node generate.js -a` (`-a` will build every version `input` folder, run without `-a` to see help)
+6. Run `node create_texts_index.js` (this creates a list of all versions to startup the app)
 
 ### Adding Bibles/Texts ###
 

--- a/tools/textgenerator/package.json
+++ b/tools/textgenerator/package.json
@@ -5,12 +5,13 @@
   "description": "Generates HTML bibles for BrowserBible",
   "dependencies" : {
     "jquery"   :  "*",
-    "uglifyjs" : "*",
+    "uglify-js" : "*",
     "uglifycss" : "*",
     "jsdom"    :  "*",
     "progress": "*",
     "minimist": "*",
-    "mkdirp": "*"
+    "mkdirp": "*",
+    "natural": "*"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I'm just fiddling, but I received this error when I tried `npm install` within `tools/textgenrator`:

    npm WARN package.json browserbible_generator@0.0.1 No repository field.
    npm WARN package.json browserbible_generator@0.0.1 No README data
    npm ERR! 404 Not Found
    npm ERR! 404 
    npm ERR! 404 'uglifyjs' is not in the npm registry.
    npm ERR! 404 You should bug the author to publish it
    npm ERR! 404 It was specified as a dependency of 'browserbible_generator'
    npm ERR! 404 
    npm ERR! 404 Note that you can also install from a
    npm ERR! 404 tarball, folder, or http url, or git url.

    npm ERR! System Linux 3.16.0-24-generic
    npm ERR! command "/usr/bin/nodejs" "/usr/bin/npm" "install"
    npm ERR! cwd /home/meshach/Documents/github/browserbible-3/tools/textgenerator
    npm ERR! node -v v0.10.25
    npm ERR! npm -v 1.4.21
    npm ERR! code E404
    npm ERR! 
    npm ERR! Additional logging details can be found in:
    npm ERR!     /home/meshach/Documents/github/browserbible-3/tools/textgenerator/npm-debug.log
    npm ERR! not ok code 0


This pull request contains the change I made to fix my issue. Not sure if it was just my mistake, or if it is a real problem.
