### PR TITLE
Include last book in OSIS imports

### DIFF
--- a/tools/generators/osis.js
+++ b/tools/generators/osis.js
@@ -50,7 +50,7 @@ function generate(inputPath, info, createIndex, startProgress, updateProgress) {
 		startProgress(chunks.length-1, 'Books');
 
 		// run through books
-		for (var i=1; i<chunks.length-1; i++) {
+		for (var i=1; i<=chunks.length-1; i++) {
 			var bookXml = separator + chunks[i];
 
 			processBook(data, bookXml, info, inputPath, createIndex);


### PR DESCRIPTION
Revelation is currently missing in some bibles which do not contain apocrypha. A good example is the KJV2006.