### PR TITLE
CSS Grid Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 content/texts/*.*
 !content/texts/README.md
+node_modules/

--- a/src/css/core.css
+++ b/src/css/core.css
@@ -31,14 +31,19 @@ body {
     display: flex;
     flex-direction: column;
 }
-
+@supports (display: grid) {
+    .sofia-container {
+        display: grid;
+        grid-template-rows: 60px 1fr;
+    }
+}
     .sofia-header {
         height: 60px;        
         background: var(--app-header-bg-color);
         padding: 15px;
         text-align: right;
     }
-    .sofia-main {        
+    .sofia-main {
         background: black;      
         display: flex;
         flex: 2;
@@ -46,6 +51,18 @@ body {
         justify-content: space-between;
         overflow: hidden; /* needed so the windows have a fixed height */
     }
+    @supports (display: grid) {
+        .sofia-main {
+            background: var(--window-outline-color);
+            justify-content: start;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(18.75rem, 1fr));
+            grid-auto-flow: column;
+            overflow-x: auto;
+            column-gap: 1px;
+        }
+    }
+      
         .close-container {
             position: absolute;
         }

--- a/src/css/core.css
+++ b/src/css/core.css
@@ -60,6 +60,7 @@ body {
             grid-auto-flow: column;
             overflow-x: auto;
             column-gap: 1px;
+            scroll-snap-type: x mandatory;
         }
     }
       

--- a/src/css/windows.css
+++ b/src/css/windows.css
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     position: relative;
+    scroll-snap-align: start;
 }
 @supports (display: grid) {
     .sofia-window {

--- a/src/css/windows.css
+++ b/src/css/windows.css
@@ -10,7 +10,14 @@
     flex-direction: column;
     position: relative;
 }
-
+@supports (display: grid) {
+    .sofia-window {
+        border-right: 0;
+        display: unset;
+        min-width: 300px;
+    }
+}
+  
 body.dragging, body.dragging * {
     cursor: move;
 }
@@ -28,6 +35,7 @@ body.dragging, body.dragging * {
         height: 50px;        
         padding: 10px;
         display: flex;
+        align-items: center;
 
         box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
         --box-shadow: 0 5px 10px rgba(0,0,0,0.2);        
@@ -46,27 +54,33 @@ body.dragging, body.dragging * {
         display: flex;
     }
     .sofia-window-close-container {
-        position: absolute;
+        margin-left: auto;
+        order: 1;
+        /* position: absolute;
         top: 0;
         right: 0;
-        height: 40px;
-        width: 40px;
-        z-index: 10;
+        z-index: 10; */        
     }
     .sofia-window-close-button {
         font-family: arial;
         font-size: 15px;
-        position: absolute;
+        /* position: absolute;
         z-index: 10;
         top: 15px;
-        right: 10px;
+        right: 10px; */
         cursor: pointer;
         color: #666;
-        width: 20px;
+        /* width: 20px;
         height: 20px;
-        border-radius: 10px;
+        border-radius: 10px; */
+        height: 40px;
+        width: 40px;
+        padding: 0;
         text-align: center; 
         font-size: 18px;
+        background: transparent;
+        border: 0;
+        border-radius: 0;
     }
     .sofia-window-close-button::after {
         content: '×';    

--- a/src/js/core/window.js
+++ b/src/js/core/window.js
@@ -32,8 +32,8 @@ class Window extends Dispatcher {
         this.body = $(`<div class="sofia-window-body"></div>`).appendTo(this.node);
 
         // buttons
-        this.closeBtn = $(`<div class="sofia-window-close-container"><span class="sofia-window-close-button"></span></div>`)
-		 			.appendTo(this.node)
+        this.closeBtn = $(`<div class="sofia-window-close-container"><button class="sofia-window-close-button" type="button"></buton></div>`)
+		 			.appendTo(this.header)
 		 			.find('.sofia-window-close-button')
 					.on('click', (e) => {                        
                         this.manager.removeWindow(this.id);


### PR DESCRIPTION
Added CSS Grid for supporting browser and allowed for side-scrolling (native scrollbar, currently) with scroll-snap enabled so it's a clean horizontal scroll.

One minor change was to move the close button for each window into the same container as the text dropdowns so we could avoid having to absolute position it and allow the button to flow a bit better on smaller screens.

Lastly, the selfsame button was converted to a `<button>` for accessibility (keyboard access, primarily) reasons.